### PR TITLE
Update ScriptTemplate.cs

### DIFF
--- a/Bitcoin Tool/Scripts/ScriptTemplate.cs
+++ b/Bitcoin Tool/Scripts/ScriptTemplate.cs
@@ -77,7 +77,7 @@ namespace Bitcoin_Tool.Scripts
 
 		public static Boolean IsPayToMultiSig(this Script s)
 		{
-			int i = s.elements.Count;
+			int i = s.elements.Count - 1;
 			if (s.elements[i--].opCode != OpCode.OP_CHECKMULTISIG)
 				return false;
 			if (!s.elements[i--].matchesSmallInteger)


### PR DESCRIPTION
Fixed IndexOutOfRangeException for MultiSig. The original code accesses s.elements[s.elements.Count], which is an off-by-one error.
